### PR TITLE
Set /home as default workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,4 @@ RUN apt-get update -qq &&\
            /var/tmp/* \
            install-tl-unx.tar.gz
 
+WORKDIR /home


### PR DESCRIPTION
The documentation says that `/home` should be used as mapping target - see https://github.com/adinriv/docker-texlive#build-tex-documents-1.

However, there is no `WORKDIR` statement in the Dockerfiles and according to https://stackoverflow.com/a/37782568/873282 the default workdir is `/`.

With this PR, this should be fixed both for docker-minimal-texlive and docker-texlive.